### PR TITLE
Fix exception when setting same custom variable slot ID more than once

### DIFF
--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -337,15 +337,15 @@ namespace Piwik.Tracker
             switch (scope)
             {
                 case CustomVar.Scopes.page:
-                    pageCustomVar.Add(stringId, customVar);
+                    pageCustomVar[stringId] = customVar;
                     break;
 
                 case CustomVar.Scopes.visit:
-                    visitorCustomVar.Add(stringId, customVar);
+                    visitorCustomVar[stringId] = customVar;
                     break;
 
                 case CustomVar.Scopes._event:
-                    eventCustomVar.Add(stringId, customVar);
+                    eventCustomVar[stringId] = customVar;
                     break;
 
                 default:


### PR DESCRIPTION
If I call `setCustomVariable()` more than once given the same slot ID, the following exception is thrown:

```
System.ArgumentException: An item with the same key has already been added.
   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   at Piwik.Tracker.PiwikTracker.setCustomVariable(Int32 id, String name, String value, Scopes scope)
```

This is caused by the fact that `setCustomVariable()` doesn't first check that the given slot ID is already there before adding it to the dictionary. This can be addressed by avoiding the `Add()` method altogether (since it would require ensuring the key doesn't already exist) and using the direct key reference.