### PR TITLE
Proxy setup

### DIFF
--- a/Piwik.Tracker.Samples/PiwikTrackerSamples.cs
+++ b/Piwik.Tracker.Samples/PiwikTrackerSamples.cs
@@ -28,6 +28,9 @@ namespace Piwik.Tracker.Samples
             // ** CUSTOM VARIABLES **
 //            RecordCustomVariables();
 
+            // ** CUSTOM DIMENSIONS **
+//            RecordCustomDimensions();
+
             // ** GOAL CONVERSION **
 //            GoalConversion();
 //            GoalConversionWithAttributionInfo();
@@ -85,6 +88,22 @@ namespace Piwik.Tracker.Samples
 
             piwikTracker.setCustomVariable(1, "pagevar1", "pagevalue1", CustomVar.Scopes.page);
             piwikTracker.setCustomVariable(2, "pagevar2", "pagevalue2", CustomVar.Scopes.page);
+
+            var response = piwikTracker.doTrackPageView("Document title of current page view");
+
+            displayDebugInfo(response);
+        }
+
+        /// <summary>
+        /// Records 2 custom dimensions
+        /// </summary>
+        static private void RecordCustomDimensions()
+        {
+            var piwikTracker = new PiwikTracker(1);
+            piwikTracker.setUserAgent(UA);
+
+            piwikTracker.setCustomTrackingParameter("dimension1", "value1");
+            piwikTracker.setCustomTrackingParameter("dimension2", "value2");
 
             var response = piwikTracker.doTrackPageView("Document title of current page view");
 

--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -1486,6 +1486,7 @@ namespace Piwik.Tracker
 
                 // Clear custom variables so they don't get copied over to other users in the bulk request
                 this.clearCustomVariables();
+                this.clearCustomTrackingParameters();
                 this.userAgent = null;
                 this.acceptLanguage = null;
     		    return null;

--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -746,7 +746,7 @@ namespace Piwik.Tracker
     	
     	    var data = new Dictionary<string, Object>();
             data["requests"] = this.storedTrackingActions;
-
+    
             // token_auth is not required by default, except if bulk_requests_require_authentication=1
             if(!string.IsNullOrWhiteSpace(this.token_auth)) {
                 data["token_auth"] = this.token_auth;
@@ -778,6 +778,22 @@ namespace Piwik.Tracker
         {
     	    string url = getUrlTrackEcommerceOrder(orderId, grandTotal, subTotal, tax, shipping, discount);
     	    return sendRequest(url); 
+        }
+
+
+        /// <summary>
+        /// Sends a ping request.
+        /// 
+        /// Ping requests do not track new actions. If they are sent within the standard visit length (see global.ini.php),
+        /// they will extend the existing visit and the current last action for the visit. If after the standard visit length,
+        /// ping requests will create a new visit using the last action in the last known visit.
+        /// </summary>
+        /// <returns>HTTP Response from the server or null if using bulk requests.</returns>
+        public HttpWebResponse doPing()
+        {
+            var url = this.getRequest(this.idSite);
+            url += "&ping=1";
+            return this.sendRequest(url);
         }
 
 

--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -145,6 +145,7 @@ namespace Piwik.Tracker
         private Dictionary<string, string[]> visitorCustomVar;
         private Dictionary<string, string[]> pageCustomVar;
         private Dictionary<string, string[]> eventCustomVar;
+        private Dictionary<string, string> customParameters;
         private string customData;
         private DateTimeOffset forcedDatetime;
         private bool forcedNewVisit;
@@ -207,6 +208,7 @@ namespace Piwik.Tracker
             this.plugins = null;            
             this.pageCustomVar = new Dictionary<string, string[]>();
             this.eventCustomVar = new Dictionary<string, string[]>();
+            this.customParameters = new Dictionary<string, string>();
             this.customData = null;
             this.forcedDatetime = DateTimeOffset.MinValue;
             this.forcedNewVisit = false;
@@ -363,6 +365,19 @@ namespace Piwik.Tracker
             }
         }
 
+        /// <summary>
+        /// Sets a custom tracking parameter
+        /// <para></para>
+        /// To track custom dimensions use 'dimension{#}' as the value for
+        /// <paramref name="trackingApiParameter"/>, e.g. dimension1.
+        /// </summary>
+        /// <param name="trackingApiParameter">The name of the custom tracking parameter. Use dimension{#} for custom dimensions, e.g. dimension1 for dimension 1.</param>
+        /// <param name="value">The value of the custom parameter</param>
+        public void setCustomTrackingParameter(string trackingApiParameter, string value)
+        {
+            customParameters[trackingApiParameter] = value;
+        }
+
 
         /// <summary>
         /// Returns the currently assigned Custom Variable.
@@ -397,6 +412,16 @@ namespace Piwik.Tracker
             return new CustomVar(cookieDecoded[stringId][0], cookieDecoded[stringId][1]);
         }
 
+        /// <summary>
+        /// Returns the currently assigned value for the given custom tracking parameter
+        /// </summary>
+        /// <param name="trackingApiParameter">The name of the custom tracking parameter</param>
+        /// <returns>The value of the custom tracking parameter</returns>
+        public string getCustomTrackingParameter(string trackingApiParameter)
+        {
+            return customParameters.ContainsKey(trackingApiParameter) ? customParameters[trackingApiParameter] : "";
+        }
+
 
         /// <summary>
         /// Clears any Custom Variable that may be have been set.
@@ -409,6 +434,14 @@ namespace Piwik.Tracker
             this.visitorCustomVar = new Dictionary<string, string[]>();
             this.pageCustomVar = new Dictionary<string, string[]>();
             this.eventCustomVar = new Dictionary<string, string[]>();
+        }
+
+        /// <summary>
+        /// Clears any custom tracking parameters that have been set.
+        /// </summary>
+        public void clearCustomTrackingParameters()
+        {
+            this.customParameters = new Dictionary<string, string>();
         }
 
         
@@ -1498,6 +1531,15 @@ namespace Piwik.Tracker
         {   	
             this.setFirstPartyCookies();
 
+            var customFields = "";
+            if (this.customParameters.Any())
+            {
+                foreach (var kvp in customParameters)
+                {
+                    customFields += string.Format("&{0}={1}", this.urlEncode(kvp.Key), this.urlEncode(kvp.Value));
+                }
+            }
+
             var url = this.getBaseUrl() +
                 "?idsite=" + idSite +
 		        "&rec=1" +
@@ -1553,6 +1595,7 @@ namespace Piwik.Tracker
     		    (!string.IsNullOrEmpty(this.city) ? "&city=" + urlEncode(this.city) : "") +
                 (this.lat != null ? "&lat=" + formatGeoLocationValue((float) this.lat) : "") +
                 (this.longitude != null ? "&long=" + formatGeoLocationValue((float) this.longitude) : "") +
+                customFields +
                 (!this.sendImageResponse ? "&send_image=0" : "") +
 
     	        // DEBUG 
@@ -1562,6 +1605,7 @@ namespace Piwik.Tracker
             // Reset page level custom variables after this page view
             pageCustomVar = new Dictionary<string ,string[]>();
             eventCustomVar = new Dictionary<string ,string[]>();
+            this.clearCustomTrackingParameters();
 
             // force new visit only once, user must call again setForceNewVisit()
             this.forcedNewVisit = false;

--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -185,6 +185,7 @@ namespace Piwik.Tracker
         private long? currentVisitTs;
         private long? lastVisitTs;
         private long? lastEcommerceOrderTs;
+        private bool sendImageResponse;
         private IWebProxy proxy;
 
         public enum ActionType {download, link};
@@ -265,6 +266,8 @@ namespace Piwik.Tracker
     	    this.requestTimeout = 600;
     	    this.doBulkRequests = false;
     	    this.storedTrackingActions = new List<string>();
+
+            this.sendImageResponse = true;
 
             this.visitorCustomVar = this.getCustomVariablesFromCookie();
         }
@@ -536,6 +539,13 @@ namespace Piwik.Tracker
             this.configCookiePath = path;
         }
 
+        /// <summary>
+        /// If image response is disabled Piwik will respond with a HTTP 204 header instead of responding with a gif.
+        /// </summary> 
+        public void disableSendImageResponse()
+        {
+            this.sendImageResponse = false;
+        }
 
         /// <summary>
         /// Fix-up domain
@@ -1527,6 +1537,7 @@ namespace Piwik.Tracker
     		    (!string.IsNullOrEmpty(this.city) ? "&city=" + urlEncode(this.city) : "") +
                 (this.lat != null ? "&lat=" + formatGeoLocationValue((float) this.lat) : "") +
                 (this.longitude != null ? "&long=" + formatGeoLocationValue((float) this.longitude) : "") +
+                (!this.sendImageResponse ? "&send_image=0" : "") +
 
     	        // DEBUG 
 	            DEBUG_APPEND_URL;

--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -185,6 +185,7 @@ namespace Piwik.Tracker
         private long? currentVisitTs;
         private long? lastVisitTs;
         private long? lastEcommerceOrderTs;
+        private IWebProxy proxy;
 
         public enum ActionType {download, link};
 
@@ -1148,6 +1149,14 @@ namespace Piwik.Tracker
     	    this.forcedVisitorId = visitorId;
         }
 
+        /// <summary>
+        /// Sets the proxy used for web-requests.
+        /// </summary>
+        /// <param name="proxy">The proxy.</param>
+        public void setProxy(IWebProxy proxy)
+        {
+            this.proxy = proxy;
+        }
 
         /// <summary>
         /// If the user initiating the request has the Piwik first party cookie, 
@@ -1184,6 +1193,14 @@ namespace Piwik.Tracker
             return this.userId;
         }
 
+        /// <summary>
+        /// Gets the proxy used for web-requests, or <c>null</c> if no proxy is used.
+        /// </summary>
+        /// <returns></returns>
+        public IWebProxy getProxy()
+        {
+            return this.proxy;
+        }
 
         /// <summary>
         /// Loads values from the VisitorId Cookie
@@ -1420,6 +1437,10 @@ namespace Piwik.Tracker
             request.UserAgent = this.userAgent;            
             request.Headers.Add("Accept-Language", acceptLanguage);
             request.Timeout = this.requestTimeout*1000;
+            if (this.proxy !=null)
+            {
+                request.Proxy = this.proxy;
+            }
 
             if (!string.IsNullOrEmpty(data)) {
                 request.ContentType = "application/json";

--- a/Piwik.Tracker/Properties/AssemblyInfo.cs
+++ b/Piwik.Tracker/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.8.0")]
+[assembly: AssemblyVersion("2.8.1")]

--- a/Piwik.Tracker/Properties/AssemblyInfo.cs
+++ b/Piwik.Tracker/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.8.1")]
+[assembly: AssemblyVersion("2.8.2")]

--- a/Piwik.Tracker/Properties/AssemblyInfo.cs
+++ b/Piwik.Tracker/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.10.0")]
+[assembly: AssemblyVersion("2.11.0")]

--- a/Piwik.Tracker/Properties/AssemblyInfo.cs
+++ b/Piwik.Tracker/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.9.1")]
+[assembly: AssemblyVersion("2.10.0")]

--- a/Piwik.Tracker/Properties/AssemblyInfo.cs
+++ b/Piwik.Tracker/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.14.0")]
+[assembly: AssemblyVersion("2.16.0")]

--- a/Piwik.Tracker/Properties/AssemblyInfo.cs
+++ b/Piwik.Tracker/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.11.0")]
+[assembly: AssemblyVersion("2.11.1")]

--- a/Piwik.Tracker/Properties/AssemblyInfo.cs
+++ b/Piwik.Tracker/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.12.0")]
+[assembly: AssemblyVersion("2.14.0")]

--- a/Piwik.Tracker/Properties/AssemblyInfo.cs
+++ b/Piwik.Tracker/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.11.1")]
+[assembly: AssemblyVersion("2.12.0")]

--- a/Piwik.Tracker/Properties/AssemblyInfo.cs
+++ b/Piwik.Tracker/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.9.0")]
+[assembly: AssemblyVersion("2.9.1")]

--- a/Piwik.Tracker/Properties/AssemblyInfo.cs
+++ b/Piwik.Tracker/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.8.2")]
+[assembly: AssemblyVersion("2.8.3")]

--- a/Piwik.Tracker/Properties/AssemblyInfo.cs
+++ b/Piwik.Tracker/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.8.3")]
+[assembly: AssemblyVersion("2.9.0")]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Translating the project is a manual process and requires
 To ease the process, the following guidelines are applied to code contributions :
 
 * a commit in the PHP project implies a commit in the C# project with the same message and content
-* one-to-one tag mapping between the PHP and C# projects -> not possible anymore since the PHP Tracker was moved to its own repository and the version number was reseted to 1.0.0, solution pending
+* one-to-one tag mapping between the PHP and C# projects **not possible anymore, see #22**
 * the C# code should mirror as close as possible the PHP code
 
 ### Code style

--- a/README.md
+++ b/README.md
@@ -15,24 +15,18 @@ Three Visual Studio Solutions are provided :
 
 ## How to contribute
 
-The Piwik C# Tracking API is a translation of the [official PHP Tracking API](https://github.com/piwik/piwik/tree/master/libs/PiwikTracker) in C#.
+The Piwik C# Tracking API is a translation of the [official PHP Tracking API](https://github.com/piwik/piwik-php-tracker) in C#.
 
-Translating the project is currently a manual process.
-
-Manually translating the project is tedious because it requires
+Translating the project is a manual process and requires
 
 * identifying features that have already been translated
 * merging code
 
-We would ideally like to automate this process, we welcome contributions aimed towards this goal.
+To ease the process, the following guidelines are applied to code contributions :
 
-To ease the process in the mean time, the following rules are applied to any new code contributions :
-
-* a commit in the PHP project implies a commit in the C# project with the same message and content
-* one-to-one tag mapping between the PHP and C# projects
+* a commit in the PHP project implies a commit in the C# project with the same message and content
+* one-to-one tag mapping between the PHP and C# projects -> not possible anymore since the PHP Tracker was moved to its own repository and the version number was reseted to 1.0.0, solution pending
 * the C# code should mirror as close as possible the PHP code
-
-As long as we do not have an automated process, we welcome suggestions in improving the manual process.
 
 ### Code style
 


### PR DESCRIPTION
When the application to track runs on a computer with custom proxy configuration, web-requests can not be send by piwik-tracker. => Added the possibillity to specify a webproxy to be used for sending web-requests.

Best regards,
peter