### PR TITLE
Proxy setup

### DIFF
--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -187,6 +187,7 @@ namespace Piwik.Tracker
         private long? lastVisitTs;
         private long? lastEcommerceOrderTs;
         private bool sendImageResponse;
+        private IWebProxy proxy;
 
         public enum ActionType {download, link};
 
@@ -1243,6 +1244,14 @@ namespace Piwik.Tracker
             return this.userId;
         }
 
+        /// <summary>
+        /// Gets the proxy used for web-requests, or <c>null</c> if no proxy is used.
+        /// </summary>
+        /// <returns></returns>
+        public IWebProxy getProxy()
+        {
+            return this.proxy;
+        }
 
         /// <summary>
         /// Loads values from the VisitorId Cookie
@@ -1480,6 +1489,10 @@ namespace Piwik.Tracker
             request.UserAgent = this.userAgent;            
             request.Headers.Add("Accept-Language", acceptLanguage);
             request.Timeout = this.requestTimeout*1000;
+            if (this.proxy != null)
+            {
+                request.Proxy = this.proxy;
+            }
 
             if (!string.IsNullOrEmpty(data)) {
                 request.ContentType = "application/json";
@@ -1731,6 +1744,14 @@ namespace Piwik.Tracker
             }
         }
 
+        /// <summary>
+        /// Sets the proxy used for web-requests.
+        /// </summary>
+        /// <param name="proxy">The proxy.</param>
+        public void setProxy(IWebProxy proxy)
+        {
+            this.proxy = proxy;
+        }
 
         protected Dictionary<string, string[]> getCustomVariablesFromCookie()
         {


### PR DESCRIPTION
When the application to track runs on a computer with custom proxy configuration, web-requests can not be send by piwik-tracker. => Added the possibillity to specify a webproxy to be used for sending web-requests.

Best regards,
peter