### PR TITLE
Split sendRequest into sendRequest and buildRequest

### DIFF
--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -1464,7 +1464,10 @@ namespace Piwik.Tracker
         /// </summary>
         static public string DEBUG_LAST_REQUESTED_URL;
 
-        private HttpWebResponse sendRequest(string url, string method = "GET", string data = null, bool force = false)
+        /// <summary>
+        /// Builds a new request object
+        /// </summary>
+        protected virtual HttpWebRequest buildRequest(string url, string method = "GET", string data = null, bool force = false)
         {
             DEBUG_LAST_REQUESTED_URL = url;
 
@@ -1492,6 +1495,17 @@ namespace Piwik.Tracker
             if (this.proxy != null)
             {
                 request.Proxy = this.proxy;
+            }
+
+            return request;
+        }
+
+        protected HttpWebResponse sendRequest(string url, string method = "GET", string data = null, bool force = false)
+        {
+            var request = buildRequest(url, method, data, force);
+            if (request == null)
+            {
+                return null;
             }
 
             if (!string.IsNullOrEmpty(data)) {


### PR DESCRIPTION
This allows for modifications of the request object via overriding the buildRequest method in a customized PiwikTracker class and calling base.buildRequest() first.

This is a very basic change which can make a big improvement. Right now, if someone has to change a the tiniest setting on the request (i.e. enable windows authentication credentials, basic auth credentials, or anything else), he cannot use the complete implementation of the PiwikTracker.

A even more basic change would be to atleast make the sendRequest protected (as it is in the PHP implementation), but this would than require to re-implement the complete sendRequest for such small request object changes.

With the attached pull request, the following would be possible:


    public class CustomPiwikTracker : PiwikTracker
    {
        public CustomPiwikTracker(int idSite, string apiUrl = "") : base(idSite, apiUrl)
        {
        }

        protected override HttpWebRequest buildRequest(string url, string method = "GET", string data = null, bool force = false)
        {
            var request = base.buildRequest(url, method, data, force);
            // change request
            return request;
        }
    }