### PR TITLE
dispose HttpWebResponse in order to fix problems with timeout after m…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.sln.dotsettings.user
 */*.csproj.dotsettings.user
 *.nupkg
+.vs/
+packages/

--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -628,7 +628,7 @@ namespace Piwik.Tracker
         /// </summary>       
         /// <param name="documentTitle">Page title as it will appear in the Actions > Page titles report</param> 
         /// <returns>HTTP Response from the server or null if using bulk requests.</returns>
-        public HttpWebResponse doTrackPageView(string documentTitle = null)
+        public HttpStatusCode?  doTrackPageView(string documentTitle = null)
         {
             string url = getUrlTrackPageView(documentTitle);
             return sendRequest(url);
@@ -643,7 +643,7 @@ namespace Piwik.Tracker
         /// <param name="name">(optional) The Event's object Name (a particular Movie name, or Song name, or File name...)</param> 
         /// <param name="value">(optional) The Event's value</param> 
         /// <returns>HTTP Response from the server or null if using bulk requests.</returns>
-        public HttpWebResponse doTrackEvent(string category, string action, string name = "", string value = "")
+        public HttpStatusCode? doTrackEvent(string category, string action, string name = "", string value = "")
         {
             var url = this.getUrlTrackEvent(category, action, name, value);
             return this.sendRequest(url);
@@ -657,7 +657,7 @@ namespace Piwik.Tracker
         /// <param name="contentPiece">The actual content. For instance the path to an image, video, audio, any text</param> 
         /// <param name="contentTarget">(optional) The target of the content. For instance the URL of a landing page.</param> 
         /// <returns>HTTP Response from the server or null if using bulk requests.</returns>
-        public HttpWebResponse doTrackContentImpression(string contentName, string contentPiece = "Unknown", string contentTarget = null)
+        public HttpStatusCode? doTrackContentImpression(string contentName, string contentPiece = "Unknown", string contentTarget = null)
         {
             var url = this.getUrlTrackContentImpression(contentName, contentPiece, contentTarget);
             return this.sendRequest(url);
@@ -673,7 +673,7 @@ namespace Piwik.Tracker
         /// <param name="contentPiece">The actual content. For instance the path to an image, video, audio, any text</param> 
         /// <param name="contentTarget">(optional) The target the content leading to when an interaction occurs. For instance the URL of a landing page.</param> 
         /// <returns>HTTP Response from the server or null if using bulk requests.</returns>
-        public HttpWebResponse doTrackContentInteraction(string interaction, string contentName, string contentPiece = "Unknown", string contentTarget = null)
+        public HttpStatusCode? doTrackContentInteraction(string interaction, string contentName, string contentPiece = "Unknown", string contentTarget = null)
         {
             var url = this.getUrlTrackContentInteraction(interaction, contentName, contentPiece, contentTarget);
             return this.sendRequest(url);
@@ -688,7 +688,7 @@ namespace Piwik.Tracker
         /// <param name="category">(optional) Search engine category if applicable</param> 
         /// <param name="countResults">(optional) results displayed on the search result page. Used to track "zero result" keywords.</param> 
         /// <returns>HTTP Response from the server or null if using bulk requests.</returns>
-	    public HttpWebResponse doTrackSiteSearch(string keyword, string category = "", int? countResults = null)
+	    public HttpStatusCode? doTrackSiteSearch(string keyword, string category = "", int? countResults = null)
 	    {
 		    var url = this.getUrlTrackSiteSearch(keyword, category, countResults);
 		    return this.sendRequest(url);
@@ -701,7 +701,7 @@ namespace Piwik.Tracker
         /// <param name="idGoal">Id Goal to record a conversion</param> 
         /// <param name="revenue">Revenue for this conversion</param> 
         /// <returns>HTTP Response from the server or null if using bulk requests.</returns>
-        public HttpWebResponse doTrackGoal(int idGoal, float revenue = 0)
+        public HttpStatusCode? doTrackGoal(int idGoal, float revenue = 0)
         {
     	    string url = getUrlTrackGoal(idGoal, revenue);
     	    return sendRequest(url);
@@ -714,7 +714,7 @@ namespace Piwik.Tracker
         /// <param name="actionUrl">URL of the download or outlink</param> 
         /// <param name="actionType">Type of the action: 'download' or 'link'</param> 
         /// <returns>HTTP Response from the server or null if using bulk requests.</returns>
-        public HttpWebResponse doTrackAction(string actionUrl, ActionType actionType)
+        public HttpStatusCode? doTrackAction(string actionUrl, ActionType actionType)
         {
             // Referrer could be udpated to be the current URL temporarily (to mimic JS behavior)
     	    string url = getUrlTrackAction(actionUrl, actionType);
@@ -758,7 +758,7 @@ namespace Piwik.Tracker
         /// </summary>       
         /// <param name="grandTotal">Cart grandTotal (typically the sum of all items' prices)</param> 
         /// <returns>HTTP Response from the server or null if using bulk requests.</returns>
-        public HttpWebResponse doTrackEcommerceCartUpdate(double grandTotal)
+        public HttpStatusCode? doTrackEcommerceCartUpdate(double grandTotal)
         {
     	    string url = getUrlTrackEcommerceCartUpdate(grandTotal);
     	    return sendRequest(url); 
@@ -771,7 +771,7 @@ namespace Piwik.Tracker
         /// </summary>   
         /// <exception cref="Exception"/>    
         /// <returns>Response</returns>
-        public HttpWebResponse doBulkTrack()
+        public HttpStatusCode doBulkTrack()
         {
     	    if (!this.storedTrackingActions.Any()) {
                 throw new Exception("Error:  you must call the function doTrackPageView or doTrackGoal from this class, before calling this method doBulkTrack()");
@@ -790,7 +790,7 @@ namespace Piwik.Tracker
     	
     	    this.storedTrackingActions = new List<string>();
     	
-    	    return response;
+    	    return  response.Value;
         }
 
         /// <summary>
@@ -807,7 +807,7 @@ namespace Piwik.Tracker
         /// <param name="shipping">Shipping amount for this order</param> 
         /// <param name="discount">Discounted amount in this order</param> 
         /// <returns>HTTP Response from the server or null if using bulk requests.</returns>
-        public HttpWebResponse doTrackEcommerceOrder(string orderId, double grandTotal, double subTotal = 0, double tax = 0, double shipping = 0, double discount = 0)
+        public HttpStatusCode? doTrackEcommerceOrder(string orderId, double grandTotal, double subTotal = 0, double tax = 0, double shipping = 0, double discount = 0)
         {
     	    string url = getUrlTrackEcommerceOrder(orderId, grandTotal, subTotal, tax, shipping, discount);
     	    return sendRequest(url); 
@@ -822,7 +822,7 @@ namespace Piwik.Tracker
         /// ping requests will create a new visit using the last action in the last known visit.
         /// </summary>
         /// <returns>HTTP Response from the server or null if using bulk requests.</returns>
-        public HttpWebResponse doPing()
+        public HttpStatusCode? doPing()
         {
             var url = this.getRequest(this.idSite);
             url += "&ping=1";
@@ -1464,7 +1464,7 @@ namespace Piwik.Tracker
         /// </summary>
         static public string DEBUG_LAST_REQUESTED_URL;
 
-        private HttpWebResponse sendRequest(string url, string method = "GET", string data = null, bool force = false)
+        private HttpStatusCode? sendRequest(string url, string method = "GET", string data = null, bool force = false)
         {
             DEBUG_LAST_REQUESTED_URL = url;
 
@@ -1500,8 +1500,10 @@ namespace Piwik.Tracker
                     streamWriter.Write(data);
                 }
             }
-
-            return (HttpWebResponse) request.GetResponse();
+            using (var response = (HttpWebResponse)request.GetResponse())
+            {
+                return response.StatusCode;
+            }          
         }
 
         /// <summary>


### PR DESCRIPTION
Like #27 I also realized problems with timeouts when sending multiple requests. When I send 2 requests in succession the third request always ends with a timeout exception. The suggested solution in #27 fixes this problem but results in a object disposed exception when the consumer access the HttpWebResponse object. Therefore I decided to change the interface of the tracker in order to return just the HttpStatusCode instead of HttpWebResponse. I also do not see any advantages for the consumer to handle with the HttpWebResponse object.