### PR TITLE
Implemented UnitTests

### DIFF
--- a/Piwik.Tracker.Tests/Piwik.Tracker.Tests.csproj
+++ b/Piwik.Tracker.Tests/Piwik.Tracker.Tests.csproj
@@ -9,8 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Piwik.Tracker.Tests</RootNamespace>
     <AssemblyName>Piwik.Tracker.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,12 +33,49 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="SimpleHttpMock, Version=1.1.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SimpleHttpMock.1.1.5\lib\net461\SimpleHttpMock.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Owin, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -45,10 +85,15 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="PiwikTrackerTests.cs" />
+    <Compile Include="PiwikTrackerWithMockedServerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnitTestExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="app.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Piwik.Tracker\Piwik.Tracker.csproj">
@@ -57,6 +102,13 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Piwik.Tracker.Tests/PiwikTrackerTests.cs
+++ b/Piwik.Tracker.Tests/PiwikTrackerTests.cs
@@ -234,7 +234,6 @@ namespace Piwik.Tracker.Tests
             _sut.SetNewVisitorId();
             //Assert
             var actual = _sut.GetVisitorId();
-            Console.WriteLine(actual);
             Assert.That(actual, Is.Not.Null.Or.Empty);
             Assert.That(actual, Is.Not.EqualTo(initalVisitorId));
             var request = _sut.GetRequest(SiteId);

--- a/Piwik.Tracker.Tests/PiwikTrackerTests.cs
+++ b/Piwik.Tracker.Tests/PiwikTrackerTests.cs
@@ -1,62 +1,591 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Web;
+using System.Web.Script.Serialization;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace Piwik.Tracker.Tests
 {
     [TestFixture]
-    public class PiwikTrackerTests
+    internal class PiwikTrackerTests
     {
         private const string UA = "Firefox";
-        private static readonly string PiwikBaseUrl = "http://piwik.local";
-        private static readonly int SiteId = 1;
+        private const string PiwikBaseUrl = "http://piwik.local";
+        private const int SiteId = 1;
+        private PiwikTracker _sut;
 
-        [Test]
-        [TestCase(Scopes.Page, null, null, null)]
-        [TestCase(Scopes.Page, 2, null, null)]
-        [TestCase(Scopes.Page, 2, "myPageVar", "myPageVarValue")]
-        [TestCase(Scopes.Event, null, null, null)]
-        [TestCase(Scopes.Event, 3, null, null)]
-        [TestCase(Scopes.Event, 3, "myEventVar", "myEventVarValue")]
-        [TestCase(Scopes.Visit, null, null, null)]
-        [TestCase(Scopes.Visit, 4, null, null)]
-        [TestCase(Scopes.Visit, 4, "myVisitVar", "myVisitVarValue")]
-        public void GetCustomVariable_Test(Scopes variableScope, int? variableId, string variableName, string variableValue)
+        [SetUp]
+        public void SetUpTest()
         {
-            //Arrange
-            var sut = new PiwikTracker(SiteId, PiwikBaseUrl);
-            if (variableId != null)
-            {
-                sut.SetCustomVariable(variableId.Value, variableName, variableValue, variableScope);
-            }
-            //Act
-
-            var actual = sut.GetCustomVariable(variableId ?? 99, variableScope);
-            //Assert
-            if (variableId != null)
-            {
-                Assert.That(actual.Name, Is.EqualTo(variableName));
-                Assert.That(actual.Value, Is.EqualTo(variableValue));
-            }
-            else
-            {
-                Assert.That(actual, Is.Null);
-            }
+            _sut = new PiwikTracker(SiteId, PiwikBaseUrl);
         }
 
-        [Test, Ignore("Todo: Provide ability to mock cookie!")]
-        public void GetCustomVariable_WhenScopeIsVisit_ReturnsVariableFromCookie()
+        [Test]
+        [TestCase(Scopes.Page, 2)]
+        [TestCase(Scopes.Event, 3)]
+        [TestCase(Scopes.Visit, 4)]
+        public void GetCustomVariable_WhenVariableNotSet_ReturnsNull(Scopes variableScope, int variableId)
         {
-            Assert.That(false, Is.True, "Todo: Provide ability to mock cookie!");
+            //Arrange, Act
+            var actual = _sut.GetCustomVariable(variableId, variableScope);
+            //Assert
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        [TestCase(Scopes.Page, 2, null, null)]
+        [TestCase(Scopes.Page, 2, "myPageVar", "myPageVarValue")]
+        [TestCase(Scopes.Event, 3, null, null)]
+        [TestCase(Scopes.Event, 3, "myEventVar", "myEventVarValue")]
+        [TestCase(Scopes.Visit, 4, null, null)]
+        [TestCase(Scopes.Visit, 4, "myVisitVar", "myVisitVarValue")]
+        public void GetCustomVariable_WhenVariableIsSet_ReturnsCorrectVariable(Scopes variableScope, int variableId, string variableName, string variableValue)
+        {
+            //Arrange
+            _sut.SetCustomVariable(variableId, variableName, variableValue, variableScope);
+
+            //Act
+            var actual = _sut.GetCustomVariable(variableId, variableScope);
+            //Assert
+            Assert.That(actual.Name, Is.EqualTo(variableName));
+            Assert.That(actual.Value, Is.EqualTo(variableValue));
         }
 
         [Test]
         public void GetCustomVariable_WhenInvalidScopeArgument_Throws()
         {
             //Arrange
-            var sut = new PiwikTracker(SiteId, PiwikBaseUrl);
-
             //Act & Assert
-            Assert.Throws<ArgumentException>(() => sut.GetCustomVariable(1, (Scopes)1234));
+            Assert.Throws<ArgumentException>(() => _sut.GetCustomVariable(1, (Scopes)1234));
+        }
+
+        [Test]
+        public void Ctor_WhenNoUrlProvided_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => new PiwikTracker(0, null));
+        }
+
+        [Test]
+        [TestCase("testCharset", "&cs=testCharset")]
+        [TestCase("utf16", "&cs=utf16")]
+        [TestCase("", null)]
+        public void SetPageCharset_WhenSpecified_IsAddedToRequest(string charset, string expected)
+        {
+            // Arrange, Act
+            _sut.SetPageCharset(charset);
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (string.IsNullOrEmpty(expected))
+            {
+                Assert.That(actual, Does.Not.Contain("&cs="));
+            }
+            else
+            {
+                Assert.That(actual, Does.Contain(expected));
+            }
+        }
+
+        [Test]
+        [TestCase("http://myurl.com/index.html")]
+        [TestCase("")]
+        public void SetUrl_WhenSpecified_IsAddedToRequest(string pageUrl)
+        {
+            // Arrange, Act
+            _sut.SetUrl(pageUrl);
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (string.IsNullOrEmpty(pageUrl))
+            {
+                Assert.That(actual, Does.Not.Contain("&url="));
+            }
+            else
+            {
+                Assert.That(actual, Does.Contain("&url=" + HttpUtility.UrlEncode(pageUrl)));
+            }
+        }
+
+        [Test]
+        [TestCase("http://myurlreferer.com/index.html")]
+        [TestCase("")]
+        public void SetUrlReferrer_WhenSpecified_IsAddedToRequest(string referer)
+        {
+            // Arrange, Act
+            _sut.SetUrlReferrer(referer);
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (string.IsNullOrEmpty(referer))
+            {
+                Assert.That(actual, Does.Not.Contain("&urlref="));
+            }
+            else
+            {
+                Assert.That(actual, Does.Contain("&urlref=" + HttpUtility.UrlEncode(referer)));
+            }
+        }
+
+        [Test]
+        [TestCase(55)]
+        [TestCase(null)]
+        public void SetGenerationTime_WhenSpecified_IsAddedToRequest(int? timeMs)
+        {
+            // Arrange, Act
+            if (timeMs.HasValue)
+            {
+                _sut.SetGenerationTime(timeMs.Value);
+            }
+
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (!timeMs.HasValue)
+            {
+                Assert.That(actual, Does.Not.Contain("&urlref="));
+            }
+            else
+            {
+                Assert.That(actual, Does.Contain("&gt_ms=" + timeMs));
+            }
+        }
+
+        [Test]
+        [TestCase("myCampaignName")]
+        [TestCase("")]
+        public void SetAttributionInfo_WhenCampaignNameSpecified_IsAddedToRequest(string campaignName)
+        {
+            // Arrange, Act
+            _sut.SetAttributionInfo(new AttributionInfo() { CampaignName = campaignName });
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (string.IsNullOrEmpty(campaignName))
+            {
+                Assert.That(actual, Does.Not.Contain("&_rcn="));
+            }
+            else
+            {
+                Assert.That(actual, Does.Contain("&_rcn=" + HttpUtility.UrlEncode(campaignName)));
+            }
+        }
+
+        [Test]
+        [TestCase("02/04/2017 16:51:46 +01:00")]
+        [TestCase("")]
+        public void SetAttributionInfo_WhenReferrerTimestampSpecified_IsAddedToRequest(string referrerDateTime)
+        {
+            if (string.IsNullOrEmpty(referrerDateTime))
+            {
+                // Assert
+                var actual = _sut.GetRequest(SiteId);
+                Assert.That(actual, Does.Not.Contain("&_refts="));
+            }
+            else
+            {
+                // Arrange, Act
+                var referrerTimestamp = DateTimeOffset.Parse(referrerDateTime, CultureInfo.InvariantCulture);
+                _sut.SetAttributionInfo(new AttributionInfo { ReferrerTimestamp = referrerTimestamp });
+                // Assert
+                var actual = _sut.GetRequest(SiteId);
+                Assert.That(actual, Does.Contain("&_refts=" + referrerTimestamp.ToUnixTimeSeconds().ToString().Substring(0, 6)));
+            }
+        }
+
+        [Test]
+        [TestCase("Http://myReferrerUrl.com/index.php?key=value")]
+        [TestCase("")]
+        public void SetAttributionInfo_WhenReferrerUrlSpecified_IsAddedToRequest(string referrerUrl)
+        {
+            // Arrange, Act
+            _sut.SetAttributionInfo(new AttributionInfo() { ReferrerUrl = referrerUrl });
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (string.IsNullOrEmpty(referrerUrl))
+            {
+                Assert.That(actual, Does.Not.Contain("&_ref="));
+            }
+            else
+            {
+                Assert.That(actual, Does.Contain("&_ref=" + HttpUtility.UrlEncode(referrerUrl)));
+            }
+        }
+
+        [Test]
+        [TestCase("dimension1", "")]
+        [TestCase("dimension2", null)]
+        [TestCase("dimension3", "123")]
+        public void SetCustomTrackingParameter_WhenSpecified_IsAddedToRequest(string trackingApiParameter, string value)
+        {
+            // Arrange, Act
+            _sut.SetCustomTrackingParameter(trackingApiParameter, value);
+
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            Assert.That(actual, Does.Contain($"&{trackingApiParameter}={value}"));
+        }
+
+        [Test]
+        public void SetNewVisitorId_WhenSpecified_IsAddedToRequest()
+        {
+            //Arrange
+            var initalVisitorId = _sut.GetVisitorId();
+            Assert.That(initalVisitorId, Is.Not.Null.Or.Empty);
+            //Act
+            _sut.SetNewVisitorId();
+            //Assert
+            var actual = _sut.GetVisitorId();
+            Console.WriteLine(actual);
+            Assert.That(actual, Is.Not.Null.Or.Empty);
+            Assert.That(actual, Is.Not.EqualTo(initalVisitorId));
+            var request = _sut.GetRequest(SiteId);
+            Assert.That(request, Does.Contain("&_id=" + actual));
+        }
+
+        [Test]
+        [TestCase("")]
+        [TestCase("fghfügh")]
+        public void SetCountry_WhenSpecified_IsAddedToRequest(string country)
+        {
+            // Arrange, Act
+            _sut.SetCountry(country);
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (string.IsNullOrEmpty(country))
+            {
+                Assert.That(actual, Does.Not.Contain("&country="));
+            }
+            else
+            {
+                Assert.That(actual, Does.Contain("&country=" + HttpUtility.UrlEncode(country)));
+            }
+        }
+
+        [Test]
+        [TestCase("")]
+        [TestCase("fghfügh")]
+        public void SetRegion_WhenSpecified_IsAddedToRequest(string region)
+        {
+            // Arrange, Act
+            _sut.SetRegion(region);
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (string.IsNullOrEmpty(region))
+            {
+                Assert.That(actual, Does.Not.Contain("&region="));
+            }
+            else
+            {
+                Assert.That(actual, Does.Contain("&region=" + HttpUtility.UrlEncode(region)));
+            }
+        }
+
+        [Test]
+        [TestCase("")]
+        [TestCase("fghfügh")]
+        public void SetCity_WhenSpecified_IsAddedToRequest(string city)
+        {
+            // Arrange, Act
+            _sut.SetCity(city);
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (string.IsNullOrEmpty(city))
+            {
+                Assert.That(actual, Does.Not.Contain("&city="));
+            }
+            else
+            {
+                Assert.That(actual, Does.Contain("&city=" + HttpUtility.UrlEncode(city)));
+            }
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(0L)]
+        [TestCase(42L)]
+        public void SetLatitude_WhenSpecified_IsAddedToRequest(long? latitude)
+        {
+            // Arrange, Act
+            if (latitude.HasValue)
+            {
+                _sut.SetLatitude(latitude.Value);
+            }
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (!latitude.HasValue)
+            {
+                Assert.That(actual, Does.Not.Contain("&lat="));
+            }
+            else
+            {
+                Assert.That(actual, Does.Contain("&lat=" + latitude.Value.ToString(CultureInfo.InvariantCulture)));
+            }
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(0L)]
+        [TestCase(42L)]
+        public void SetLongitude_WhenSpecified_IsAddedToRequest(long? @long)
+        {
+            // Arrange, Act
+            if (@long.HasValue)
+            {
+                _sut.SetLongitude(@long.Value);
+            }
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (!@long.HasValue)
+            {
+                Assert.That(actual, Does.Not.Contain("&long="));
+            }
+            else
+            {
+                Assert.That(actual, Does.Contain("&long=" + @long.Value.ToString(CultureInfo.InvariantCulture)));
+            }
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void DisableSendImageResponse_WhenSpecified_IsAddedToRequest(bool doDisable)
+        {
+            // Arrange, Act
+            if (doDisable)
+            {
+                _sut.DisableSendImageResponse();
+            }
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (doDisable)
+            {
+                Assert.That(actual, Does.Contain("&send_image=0"));
+            }
+            else
+            {
+                Assert.That(actual, Does.Not.Contain("&send_image=0"));
+            }
+        }
+
+        [Test]
+        [TestCase("gh-.:/65%", "myName", "1,2,3", 0.70, 9223372036854775808UL)]
+        [TestCase("gh-.:/65%", "", "1,2,3", 0.570, 0UL)]
+        [TestCase("gh-.:/65%", "myName", null, 0.70, 9223372036854775808UL)]
+        [TestCase("gh-.:/65%", "myName", "1", 45763756d, 9223372036854775808UL)]
+        public void AddEcommerceItem_Test(string sku, string name, string categories, double price, ulong quantity)
+        {
+            List<string> categoryList = null;
+            if (!string.IsNullOrEmpty(categories))
+            {
+                categoryList = categories.Split(',').ToList();
+            }
+            var actual = _sut.GetUrlTrackEcommerce(0);
+            Assert.That(actual, Does.Not.Contain("ec_items"));
+            _sut.AddEcommerceItem(sku, name, categoryList, price, quantity);
+            actual = _sut.GetUrlTrackEcommerce(0);
+            var expected = new Dictionary<string, object[]>
+            {
+                { "",new object[] {sku, name, categoryList, price.ToString("0.##", CultureInfo.InvariantCulture), quantity}}
+            };
+            var expectedAsJson = new JavaScriptSerializer().Serialize(expected.Values);
+            Console.WriteLine(expectedAsJson);
+            Assert.That(actual, Does.Contain("&ec_items=" + HttpUtility.UrlEncode(expectedAsJson)));
+        }
+
+        [Test]
+        [TestCase("mySku", "myName", "1,2,3", 0.70)]
+        [TestCase("mySku", "myName", null, 0.70)]
+        [TestCase("mySku", "myName", "1,2,3", 22265460.70)]
+        public void SetEcommerceView_Test(string sku, string name, string categories, double price)
+        {
+            // Arrange
+            List<string> categoryList = null;
+            if (!string.IsNullOrEmpty(categories))
+            {
+                categoryList = categories.Split(',').ToList();
+            }
+            // Act
+            _sut.SetEcommerceView(sku, name, categoryList, price);
+            var actualRequest = _sut.GetRequest(SiteId);
+            // Assert
+            var actualRequestArguments = new Uri(actualRequest).ParseQueryString().ToKeyValuePairs().ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            var actualVariablesById = JsonConvert.DeserializeObject<Dictionary<int, object>>(actualRequestArguments["cvar"]);
+            Assert.That(actualVariablesById.Count, Is.EqualTo(4));
+            foreach (var variableById in actualVariablesById)
+            {
+                Console.WriteLine(variableById.Key + "=" + variableById.Value);
+                var variableValue = JsonConvert.DeserializeObject<string[]>(variableById.Value.ToString());
+                switch (variableById.Key)
+                {
+                    case PiwikTracker.CvarIndexEcommerceItemPrice:
+                        Assert.That(variableValue, Is.EquivalentTo(new[] { "_pkp", price.ToString("0.##", CultureInfo.InvariantCulture) }));
+                        break;
+
+                    case PiwikTracker.CvarIndexEcommerceItemName:
+                        Assert.That(variableValue, Is.EquivalentTo(new[] { "_pkn", name }));
+                        break;
+
+                    case PiwikTracker.CvarIndexEcommerceItemCategory:
+                        if (string.IsNullOrEmpty(categories))
+                        {
+                            continue;
+                        }
+                        Assert.That(variableValue, Is.EquivalentTo(new[] { "_pkc", new JavaScriptSerializer().Serialize(categoryList) }));
+                        break;
+
+                    case PiwikTracker.CvarIndexEcommerceItemSku:
+                        Assert.That(variableValue, Is.EquivalentTo(new[] { "_pks", sku }));
+                        break;
+
+                    default:
+                        throw new NotImplementedException();
+                }
+            }
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SetForceVisitDateTime_WhenSpecified_IsAddedToRequest(bool setValue)
+        {
+            // Arrange
+            var expected = DateTime.Now;
+            //Act
+            if (setValue)
+            {
+                _sut.SetForceVisitDateTime(expected);
+            }
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (setValue)
+            {
+                Assert.That(actual, Does.Contain("&cdt=" + expected.ToString("yyyy-MM-dd HH:mm:ss")));
+            }
+            else
+            {
+                Assert.That(actual, Does.Not.Contain("&cdt"));
+            }
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SetForceNewVisit_WhenSpecified_IsAddedToRequest(bool setValue)
+        {
+            // Arrange
+            //Act
+            if (setValue)
+            {
+                _sut.SetForceNewVisit();
+            }
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (setValue)
+            {
+                Assert.That(actual, Does.Contain("&new_visit=1"));
+            }
+            else
+            {
+                Assert.That(actual, Does.Not.Contain("&new_visit"));
+            }
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SetIp_WhenSpecified_IsAddedToRequest(bool setValue)
+        {
+            // Arrange
+            var expectedIp = "l30.54.2.1";
+            //Act
+            if (setValue)
+            {
+                _sut.SetIp(expectedIp);
+            }
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (setValue)
+            {
+                Assert.That(actual, Does.Contain("&cip=" + HttpUtility.UrlEncode(expectedIp)));
+            }
+            else
+            {
+                Assert.That(actual, Does.Not.Contain("&cip"));
+            }
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SetUserId_WhenSpecified_IsAddedToRequest(bool setValue)
+        {
+            // Arrange
+            var expectedId = "l30%&Ö";
+            //Act
+            if (setValue)
+            {
+                _sut.SetUserId(expectedId);
+            }
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (setValue)
+            {
+                Assert.That(actual, Does.Contain("&uid=" + HttpUtility.UrlEncode(expectedId)));
+            }
+            else
+            {
+                Assert.That(actual, Does.Not.Contain("&uid"));
+            }
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SetLocalTime_WhenSpecified_IsAddedToRequest(bool setValue)
+        {
+            // Arrange
+            var expected = DateTime.Now.AddHours(-3);
+            //Act
+            if (setValue)
+            {
+                _sut.SetLocalTime(expected);
+            }
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (setValue)
+            {
+                Assert.That(actual, Does.Contain("&h=" + expected.Hour));
+                Assert.That(actual, Does.Contain("&m=" + expected.Minute));
+                Assert.That(actual, Does.Contain("&s=" + expected.Second));
+            }
+            else
+            {
+                Assert.That(actual, Does.Not.Contain("&h="));
+                Assert.That(actual, Does.Not.Contain("&m="));
+                Assert.That(actual, Does.Not.Contain("&s="));
+            }
+        }
+
+        [Test]
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SetResolution_WhenSpecified_IsAddedToRequest(bool setValue)
+        {
+            // Arrange
+            //Act
+            if (setValue)
+            {
+                _sut.SetResolution(800, 600);
+            }
+            // Assert
+            var actual = _sut.GetRequest(SiteId);
+            if (setValue)
+            {
+                Assert.That(actual, Does.Contain("&res=800x600"));
+            }
+            else
+            {
+                Assert.That(actual, Does.Not.Contain("&res="));
+            }
         }
     }
 }

--- a/Piwik.Tracker.Tests/PiwikTrackerWithMockedServerTests.cs
+++ b/Piwik.Tracker.Tests/PiwikTrackerWithMockedServerTests.cs
@@ -1,0 +1,516 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using SimpleHttpMock;
+
+namespace Piwik.Tracker.Tests
+{
+    [TestFixture]
+    internal class PiwikTrackerWithMockedServerTests
+    {
+        private PiwikTracker _sut;
+        private MockedHttpServer _mockedPiwikServer;
+        private const string UA = "Firefox";
+        private const string PiwikBaseUrl = "http://127.0.0.1:1122/piwik.php";
+        private const int SiteId = 1;
+
+        private static readonly NameValueCollection DefaultRequestParameter = new NameValueCollection
+        {
+            { "idsite",SiteId.ToString()},
+            { "rec","1"},
+            { "apiv","1"},
+            { "url","http://unknown" },
+        };
+
+        private static readonly string[] DefaultRequestParameterKeysToRemoveFromComparison =
+        {
+            "r", // random value
+            "_idts" // _createTs from cookie
+        };
+
+        [OneTimeSetUp]
+        public void SetUpFixture()
+        {
+            _mockedPiwikServer = new MockedHttpServer(PiwikBaseUrl);
+        }
+
+        [OneTimeTearDown]
+        public void TearDownFixture()
+        {
+            _mockedPiwikServer.Dispose();
+        }
+
+        [SetUp]
+        public void SetUpTest()
+        {
+            _sut = new PiwikTracker(SiteId, PiwikBaseUrl);
+        }
+
+        [Test]
+        [TestCase("myPage")]
+        [TestCase("myPage/?Ü&")]
+        public void DoTrackPageView_Test(string documentTitle)
+        {
+            //Arrange
+            var retrieveRequest = CreateAllGetOkRequestBehavior();
+            //Act
+            var actual = _sut.DoTrackPageView(documentTitle);
+            //Assert
+            var actualRequest = retrieveRequest();
+            Assert.NotNull(actualRequest);
+            Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(actualRequest.Method, Is.EqualTo("GET"));
+            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
+            Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+            {
+                { "_idvc", "0" },// visit count
+                { "_id", _sut.GetVisitorId() }, // visitor id
+                { "action_name", documentTitle },
+            });
+        }
+
+        [Test]
+        [TestCase("myCategory", "myAction", "myName", "myValue")]
+        [TestCase("myCategory", "myAction", "myName", "")]
+        [TestCase("myCategory", "myAction", "", "myValue")]
+        public void DoTrackEvent_Test(string category, string action, string name, string value)
+        {
+            //Arrange
+            var retrieveRequest = CreateAllGetOkRequestBehavior();
+            //Act
+            var actual = _sut.DoTrackEvent(category, action, name, value);
+            //Assert
+            var actualRequest = retrieveRequest();
+            Assert.NotNull(actualRequest);
+            Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(actualRequest.Method, Is.EqualTo("GET"));
+            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
+            if (string.IsNullOrEmpty(name))
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                 {
+                     { "_idvc", "0" },// visit count
+                     { "_id", _sut.GetVisitorId() }, // visitor id
+                     { "e_c", category },
+                     { "e_a", action },
+                     { "e_v", value },
+                 });
+            }
+            else if (string.IsNullOrEmpty(value))
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                 {
+                     { "_idvc", "0" },// visit count
+                     { "_id", _sut.GetVisitorId() }, // visitor id
+                     { "e_c", category },
+                     { "e_n", name },
+                     { "e_a", action },
+                 });
+            }
+            else
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+            {
+                { "_idvc", "0" },// visit count
+                { "_id", _sut.GetVisitorId() }, // visitor id
+                { "e_c", category },
+                { "e_a", action },
+                { "e_n", name },
+                { "e_v", value },
+            });
+            }
+        }
+
+        [Test]
+        [TestCase("myCn", "mycp", "myct")]
+        [TestCase("myCn", null, "myct")]
+        [TestCase("myCn", "mycp", null)]
+        public void DoTrackContentImpression_Test(string contentName, string contentPiece, string contentTarget)
+        {
+            //Arrange
+            var retrieveRequest = CreateAllGetOkRequestBehavior();
+            //Act
+            var actual = _sut.DoTrackContentImpression(contentName, contentPiece, contentTarget);
+            //Assert
+            var actualRequest = retrieveRequest();
+            Assert.NotNull(actualRequest);
+            Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(actualRequest.Method, Is.EqualTo("GET"));
+            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
+            if (string.IsNullOrEmpty(contentPiece))
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },// visit count
+                    { "_id", _sut.GetVisitorId() }, // visitor id
+                    { "c_n", contentName },
+                    { "c_t", contentTarget },
+                });
+            }
+            else if (string.IsNullOrEmpty(contentTarget))
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },// visit count
+                    { "_id", _sut.GetVisitorId() }, // visitor id
+                    { "c_n", contentName },
+                    { "c_p", contentPiece },
+                });
+            }
+            else
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },// visit count
+                    { "_id", _sut.GetVisitorId() }, // visitor id
+                    { "c_n", contentName },
+                    { "c_p", contentPiece },
+                    { "c_t", contentTarget },
+                });
+            }
+        }
+
+        [Test]
+        [TestCase("myInteraction", "myCn", "mycp", "myct")]
+        [TestCase("myInteraction", "myCn", null, "myct")]
+        [TestCase("myInteraction", "myCn", "mycp", null)]
+        public void DoTrackContentInteraction_Test(string interaction, string contentName, string contentPiece, string contentTarget)
+        {
+            //Arrange
+            var retrieveRequest = CreateAllGetOkRequestBehavior();
+            //Act
+            var actual = _sut.DoTrackContentInteraction(interaction, contentName, contentPiece, contentTarget);
+            //Assert
+            var actualRequest = retrieveRequest();
+            Assert.NotNull(actualRequest);
+            Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(actualRequest.Method, Is.EqualTo("GET"));
+            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
+            if (string.IsNullOrEmpty(contentPiece))
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },// visit count
+                    { "_id", _sut.GetVisitorId() }, // visitor id
+                    { "c_n", contentName },
+                    { "c_t", contentTarget },
+                    { "c_i", interaction },
+                });
+            }
+            else if (string.IsNullOrEmpty(contentTarget))
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },// visit count
+                    { "_id", _sut.GetVisitorId() }, // visitor id
+                    { "c_n", contentName },
+                    { "c_p", contentPiece },
+                    { "c_i", interaction },
+                });
+            }
+            else
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },// visit count
+                    { "_id", _sut.GetVisitorId() }, // visitor id
+                    { "c_n", contentName },
+                    { "c_p", contentPiece },
+                    { "c_t", contentTarget },
+                    { "c_i", interaction },
+                });
+            }
+        }
+
+        [Test]
+        [TestCase("myKey", "myCat", 0)]
+        [TestCase("myKey", null, 1)]
+        [TestCase("myKey", "myCat", null)]
+        public void DoTrackSiteSearch_Test(string keyword, string category, int? countResults)
+        {
+            //Arrange
+            var retrieveRequest = CreateAllGetOkRequestBehavior();
+            //Act
+            var actual = _sut.DoTrackSiteSearch(keyword, category, countResults);
+            //Assert
+            var actualRequest = retrieveRequest();
+            Assert.NotNull(actualRequest);
+            Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(actualRequest.Method, Is.EqualTo("GET"));
+            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
+            if (string.IsNullOrEmpty(category))
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },
+                    { "_id", _sut.GetVisitorId() },
+                    { "search", keyword },
+                    { "search_count", countResults.ToString() },
+                });
+            }
+            else if (countResults == null)
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },
+                    { "_id", _sut.GetVisitorId() },
+                    { "search", keyword },
+                    { "search_cat", category },
+                });
+            }
+            else
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },
+                    { "_id", _sut.GetVisitorId() },
+                    { "search", keyword },
+                    { "search_cat", category },
+                    { "search_count", countResults.ToString() },
+                });
+            }
+        }
+
+        [Test]
+        [TestCase(1, 0.789f)]
+        [TestCase(1, 0f)]
+        [TestCase(120, 3655.55f)]
+        public void DoTrackGoal_Test(int idGoal, float revenue)
+        {
+            //Arrange
+            var retrieveRequest = CreateAllGetOkRequestBehavior();
+            //Act
+            var actual = _sut.DoTrackGoal(idGoal, revenue);
+            //Assert
+            var actualRequest = retrieveRequest();
+            Assert.NotNull(actualRequest);
+            Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(actualRequest.Method, Is.EqualTo("GET"));
+            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
+            if (Math.Abs(revenue) < 0.05f)
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },
+                    { "_id", _sut.GetVisitorId() },
+                    { "idgoal", idGoal.ToString() },
+                });
+            }
+            else
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },
+                    { "_id", _sut.GetVisitorId() },
+                    { "idgoal", idGoal.ToString() },
+                    { "revenue", revenue.ToString("0.##",CultureInfo.InvariantCulture) },
+                });
+            }
+        }
+
+        [Test]
+        [TestCase("https://myUrl.com/action?test=1&x=5", ActionType.Download)]
+        [TestCase("", ActionType.Link)]
+        public void DoTrackAction_Test(string actionUrl, ActionType actionType)
+        {
+            //Arrange
+            var retrieveRequest = CreateAllGetOkRequestBehavior();
+            //Act
+            var actual = _sut.DoTrackAction(actionUrl, actionType);
+            //Assert
+            var actualRequest = retrieveRequest();
+            Assert.NotNull(actualRequest);
+            Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(actualRequest.Method, Is.EqualTo("GET"));
+            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
+
+            {
+                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    {"_idvc", "0"},
+                    {"_id", _sut.GetVisitorId()},
+                    {actionType.ToString(), actionUrl},
+                });
+            }
+        }
+
+        [Test]
+        [TestCase(1)]
+        [TestCase(33465236365.4346)]
+        public void DoTrackEcommerceCartUpdate_Test(double grandTotal)
+        {
+            //Arrange
+            var retrieveRequest = CreateAllGetOkRequestBehavior();
+            //Act
+            var actual = _sut.DoTrackEcommerceCartUpdate(grandTotal);
+            //Assert
+            var actualRequest = retrieveRequest();
+            Assert.NotNull(actualRequest);
+            Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(actualRequest.Method, Is.EqualTo("GET"));
+            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
+
+            Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },
+                    { "_id", _sut.GetVisitorId() },
+                    { "idgoal", "0" },
+                    { "revenue", grandTotal.ToString("0.##",CultureInfo.InvariantCulture) },
+                });
+        }
+
+        [Test]
+        [TestCase("mytoken")]
+        [TestCase("")]
+        public async Task DoBulkTrack_Test(string token)
+        {
+            //Arrange
+            var retrieveRequest = CreateAllPostOkRequestBehavior();
+            var language = "en-gb";
+            var numberOfRequests = 20;
+            //Act
+            _sut.EnableBulkTracking();
+            _sut.SetUserAgent(UA);
+            _sut.SetBrowserLanguage(language);
+            if (!string.IsNullOrEmpty(token))
+            {
+                _sut.SetTokenAuth(token);
+            }
+            for (int i = 0; i < numberOfRequests; i++)
+            {
+                _sut.DoTrackPageView("Page" + i);
+            }
+            var expectedUrls = _sut.GetStoredTrackingActions();
+            Assert.That(_sut.GetStoredTrackingActions().Length, Is.EqualTo(numberOfRequests));
+            var actual = _sut.DoBulkTrack();
+            Assert.That(_sut.GetStoredTrackingActions().Length, Is.EqualTo(0));
+            //Assert
+            var actualRequest = retrieveRequest();
+            Assert.NotNull(actualRequest);
+            Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(actualRequest.Method, Is.EqualTo("POST"));
+            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
+            if (string.IsNullOrEmpty(token))
+            {
+                var body = JsonConvert.DeserializeObject<Dictionary<string, string[]>>(actualRequest.RequestBody.ToString()) as Dictionary<string, string[]>;
+                Assert.That(body.Keys.Count, Is.EqualTo(1));
+                Assert.That(body.Keys.First(), Is.EqualTo("requests"));
+                Assert.That(body.First().Value, Is.EquivalentTo(expectedUrls));
+            }
+            else
+            {
+                var body = JsonConvert.DeserializeObject<Dictionary<string, object>>(actualRequest.RequestBody.ToString()) as Dictionary<string, object>;
+                Assert.That(body.Keys.Count, Is.EqualTo(2));
+                Assert.That(body["token_auth"], Is.EqualTo(token));
+                Assert.That(((JArray)body["requests"]).Select(item => (string)item).ToArray(), Is.EquivalentTo(expectedUrls));
+            }
+        }
+
+        [Test]
+        [TestCase("sfaf&&Ä5", 32.32, 16.1667, 432.244, 234.324, 65.553)]
+        public void DoTrackEcommerceOrder_Test(string orderId, double grandTotal, double subTotal, double tax, double shipping, double discount)
+        {
+            //Arrange
+            var retrieveRequest = CreateAllGetOkRequestBehavior();
+            //Act
+            var actual = _sut.DoTrackEcommerceOrder(orderId, grandTotal, subTotal, tax, shipping, discount);
+            //Assert
+            var actualRequest = retrieveRequest();
+            Assert.NotNull(actualRequest);
+            Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(actualRequest.Method, Is.EqualTo("GET"));
+            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
+
+            Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },
+                    { "_id", _sut.GetVisitorId() },
+                    { "idgoal", "0" },
+                    { "revenue", grandTotal.ToString("0.##",CultureInfo.InvariantCulture) },
+                    {"ec_st", subTotal.ToString("0.##",CultureInfo.InvariantCulture) },
+                    {"ec_tx", tax.ToString("0.##",CultureInfo.InvariantCulture)  },
+                    {"ec_sh", shipping.ToString("0.##",CultureInfo.InvariantCulture) },
+                    {"ec_dt", discount.ToString("0.##",CultureInfo.InvariantCulture) },
+                    {"ec_id", orderId },
+                });
+        }
+
+        [Test]
+        public void DoPing_Test()
+        {
+            //Arrange
+            var retrieveRequest = CreateAllGetOkRequestBehavior();
+            //Act
+            var actual = _sut.DoPing();
+            //Assert
+            var actualRequest = retrieveRequest();
+            Assert.NotNull(actualRequest);
+            Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(actualRequest.Method, Is.EqualTo("GET"));
+            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
+
+            Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+                {
+                    { "_idvc", "0" },
+                    { "_id", _sut.GetVisitorId() },
+                    { "ping", "1" },
+                });
+        }
+
+        private Func<ActualRequest> CreateAllGetOkRequestBehavior()
+        {
+            var builder = new MockedHttpServerBuilder();
+            var retrieveRequest = builder
+                .WhenGet(Matchers.Regex(".*")).Respond(HttpStatusCode.OK)
+                .Retrieve();
+            builder.Build(_mockedPiwikServer);
+            return retrieveRequest;
+        }
+
+        private Func<ActualRequest> CreateAllPostOkRequestBehavior()
+        {
+            var builder = new MockedHttpServerBuilder();
+            var retrieveRequest = builder
+                .WhenPost(Matchers.Regex(".*")).Respond(HttpStatusCode.OK)
+                .Retrieve();
+            builder.Build(_mockedPiwikServer);
+            return retrieveRequest;
+        }
+
+        internal class Assert : NUnit.Framework.Assert
+        {
+            public static void PiwikRequestParameterMatch(NameValueCollection actualRequestParameter, NameValueCollection additionalExpectedParamters)
+            {
+                var expectedRequestParameter = new NameValueCollection(DefaultRequestParameter) { additionalExpectedParamters };
+                Assert.That(actualRequestParameter.AllKeys, Is.SupersetOf(DefaultRequestParameterKeysToRemoveFromComparison),
+                    $"Request parameters must at least contain default Keys {string.Join(",", DefaultRequestParameterKeysToRemoveFromComparison)}.");
+
+                // remove random default values!
+                foreach (var key in DefaultRequestParameterKeysToRemoveFromComparison)
+                {
+                    actualRequestParameter.Remove(key);
+                }
+
+                Assert.That(actualRequestParameter.AllKeys, Is.EquivalentTo(expectedRequestParameter.AllKeys),
+                    () => GetEnhancedMessage("Request parameter keys must be equivalent!", actualRequestParameter, expectedRequestParameter));
+                Assert.That(actualRequestParameter.AllKeys.Select(k => actualRequestParameter[k]), Is.EquivalentTo(expectedRequestParameter.AllKeys.Select(k => expectedRequestParameter[k])),
+                    () => GetEnhancedMessage("Request parameter values must be equivalent!", actualRequestParameter, expectedRequestParameter));
+            }
+
+            private static string GetEnhancedMessage(string message, NameValueCollection actualParameter, NameValueCollection expectedParamters)
+            {
+                return message + Environment.NewLine +
+                    $"Expected: equivalent to <{string.Join(", ", expectedParamters.ToKeyValuePairs().OrderBy(kvp => kvp.Key).Select(kvp => "\"" + kvp.Key + ":" + kvp.Value + "\""))}>" + Environment.NewLine +
+                    $"But was: <{string.Join(", ", actualParameter.ToKeyValuePairs().OrderBy(kvp => kvp.Key).Select(kvp => "\"" + kvp.Key + ":" + kvp.Value + "\""))}>";
+            }
+        }
+    }
+}

--- a/Piwik.Tracker.Tests/PiwikTrackerWithMockedServerTests.cs
+++ b/Piwik.Tracker.Tests/PiwikTrackerWithMockedServerTests.cs
@@ -65,11 +65,9 @@ namespace Piwik.Tracker.Tests
             var actual = _sut.DoTrackPageView(documentTitle);
             //Assert
             var actualRequest = retrieveRequest();
-            Assert.NotNull(actualRequest);
             Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(actualRequest.Method, Is.EqualTo("GET"));
-            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
-            Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+            Assert.PiwikRequestParameterMatch(actualRequest, new NameValueCollection
             {
                 { "_idvc", "0" },// visit count
                 { "_id", _sut.GetVisitorId() }, // visitor id
@@ -85,48 +83,29 @@ namespace Piwik.Tracker.Tests
         {
             //Arrange
             var retrieveRequest = CreateAllGetOkRequestBehavior();
+            var expectedParameter = new NameValueCollection
+            {
+                {"_idvc", "0"}, // visit count
+                {"_id", _sut.GetVisitorId()}, // visitor id
+                {"e_c", category},
+                {"e_a", action},
+            };
             //Act
             var actual = _sut.DoTrackEvent(category, action, name, value);
             //Assert
             var actualRequest = retrieveRequest();
-            Assert.NotNull(actualRequest);
             Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(actualRequest.Method, Is.EqualTo("GET"));
-            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
-            if (string.IsNullOrEmpty(name))
+            if (!string.IsNullOrEmpty(name))
             {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                 {
-                     { "_idvc", "0" },// visit count
-                     { "_id", _sut.GetVisitorId() }, // visitor id
-                     { "e_c", category },
-                     { "e_a", action },
-                     { "e_v", value },
-                 });
+                expectedParameter.Add("e_n", name);
             }
-            else if (string.IsNullOrEmpty(value))
+            if (!string.IsNullOrEmpty(value))
             {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                 {
-                     { "_idvc", "0" },// visit count
-                     { "_id", _sut.GetVisitorId() }, // visitor id
-                     { "e_c", category },
-                     { "e_n", name },
-                     { "e_a", action },
-                 });
+                expectedParameter.Add("e_v", value);
             }
-            else
-            {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-            {
-                { "_idvc", "0" },// visit count
-                { "_id", _sut.GetVisitorId() }, // visitor id
-                { "e_c", category },
-                { "e_a", action },
-                { "e_n", name },
-                { "e_v", value },
-            });
-            }
+
+            Assert.PiwikRequestParameterMatch(actualRequest, expectedParameter);
         }
 
         [Test]
@@ -137,45 +116,28 @@ namespace Piwik.Tracker.Tests
         {
             //Arrange
             var retrieveRequest = CreateAllGetOkRequestBehavior();
+            var expectedParameter = new NameValueCollection
+            {
+                {"_idvc", "0"}, // visit count
+                {"_id", _sut.GetVisitorId()}, // visitor id
+                { "c_n", contentName },
+            };
             //Act
             var actual = _sut.DoTrackContentImpression(contentName, contentPiece, contentTarget);
             //Assert
             var actualRequest = retrieveRequest();
-            Assert.NotNull(actualRequest);
             Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(actualRequest.Method, Is.EqualTo("GET"));
-            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
-            if (string.IsNullOrEmpty(contentPiece))
+            if (!string.IsNullOrEmpty(contentPiece))
             {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                {
-                    { "_idvc", "0" },// visit count
-                    { "_id", _sut.GetVisitorId() }, // visitor id
-                    { "c_n", contentName },
-                    { "c_t", contentTarget },
-                });
+                expectedParameter.Add("c_p", contentPiece);
             }
-            else if (string.IsNullOrEmpty(contentTarget))
+            if (!string.IsNullOrEmpty(contentTarget))
             {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                {
-                    { "_idvc", "0" },// visit count
-                    { "_id", _sut.GetVisitorId() }, // visitor id
-                    { "c_n", contentName },
-                    { "c_p", contentPiece },
-                });
+                expectedParameter.Add("c_t", contentTarget);
             }
-            else
-            {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                {
-                    { "_idvc", "0" },// visit count
-                    { "_id", _sut.GetVisitorId() }, // visitor id
-                    { "c_n", contentName },
-                    { "c_p", contentPiece },
-                    { "c_t", contentTarget },
-                });
-            }
+
+            Assert.PiwikRequestParameterMatch(actualRequest, expectedParameter);
         }
 
         [Test]
@@ -186,48 +148,29 @@ namespace Piwik.Tracker.Tests
         {
             //Arrange
             var retrieveRequest = CreateAllGetOkRequestBehavior();
+            var expectedParameter = new NameValueCollection
+            {
+                 { "_idvc", "0" },// visit count
+                    { "_id", _sut.GetVisitorId() }, // visitor id
+                    { "c_n", contentName },
+                    { "c_i", interaction },
+            };
             //Act
             var actual = _sut.DoTrackContentInteraction(interaction, contentName, contentPiece, contentTarget);
             //Assert
             var actualRequest = retrieveRequest();
-            Assert.NotNull(actualRequest);
             Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(actualRequest.Method, Is.EqualTo("GET"));
-            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
-            if (string.IsNullOrEmpty(contentPiece))
+            if (!string.IsNullOrEmpty(contentPiece))
             {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                {
-                    { "_idvc", "0" },// visit count
-                    { "_id", _sut.GetVisitorId() }, // visitor id
-                    { "c_n", contentName },
-                    { "c_t", contentTarget },
-                    { "c_i", interaction },
-                });
+                expectedParameter.Add("c_p", contentPiece);
             }
-            else if (string.IsNullOrEmpty(contentTarget))
+            if (!string.IsNullOrEmpty(contentTarget))
             {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                {
-                    { "_idvc", "0" },// visit count
-                    { "_id", _sut.GetVisitorId() }, // visitor id
-                    { "c_n", contentName },
-                    { "c_p", contentPiece },
-                    { "c_i", interaction },
-                });
+                expectedParameter.Add("c_t", contentTarget);
             }
-            else
-            {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                {
-                    { "_idvc", "0" },// visit count
-                    { "_id", _sut.GetVisitorId() }, // visitor id
-                    { "c_n", contentName },
-                    { "c_p", contentPiece },
-                    { "c_t", contentTarget },
-                    { "c_i", interaction },
-                });
-            }
+
+            Assert.PiwikRequestParameterMatch(actualRequest, expectedParameter);
         }
 
         [Test]
@@ -238,45 +181,28 @@ namespace Piwik.Tracker.Tests
         {
             //Arrange
             var retrieveRequest = CreateAllGetOkRequestBehavior();
+            var expectedParameter = new NameValueCollection
+            {
+                 { "_idvc", "0" },// visit count
+                 { "_id", _sut.GetVisitorId() }, // visitor id
+                 { "search", keyword },
+            };
             //Act
             var actual = _sut.DoTrackSiteSearch(keyword, category, countResults);
             //Assert
             var actualRequest = retrieveRequest();
-            Assert.NotNull(actualRequest);
             Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(actualRequest.Method, Is.EqualTo("GET"));
-            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
-            if (string.IsNullOrEmpty(category))
+            if (!string.IsNullOrEmpty(category))
             {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                {
-                    { "_idvc", "0" },
-                    { "_id", _sut.GetVisitorId() },
-                    { "search", keyword },
-                    { "search_count", countResults.ToString() },
-                });
+                expectedParameter.Add("search_cat", category);
             }
-            else if (countResults == null)
+            if (countResults != null)
             {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                {
-                    { "_idvc", "0" },
-                    { "_id", _sut.GetVisitorId() },
-                    { "search", keyword },
-                    { "search_cat", category },
-                });
+                expectedParameter.Add("search_count", countResults.ToString());
             }
-            else
-            {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                {
-                    { "_idvc", "0" },
-                    { "_id", _sut.GetVisitorId() },
-                    { "search", keyword },
-                    { "search_cat", category },
-                    { "search_count", countResults.ToString() },
-                });
-            }
+
+            Assert.PiwikRequestParameterMatch(actualRequest, expectedParameter);
         }
 
         [Test]
@@ -287,33 +213,23 @@ namespace Piwik.Tracker.Tests
         {
             //Arrange
             var retrieveRequest = CreateAllGetOkRequestBehavior();
+            var expectedParameter = new NameValueCollection
+            {
+                 { "_idvc", "0" },// visit count
+                 { "_id", _sut.GetVisitorId() }, // visitor id
+                 { "idgoal", idGoal.ToString() },
+            };
             //Act
             var actual = _sut.DoTrackGoal(idGoal, revenue);
             //Assert
             var actualRequest = retrieveRequest();
-            Assert.NotNull(actualRequest);
             Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(actualRequest.Method, Is.EqualTo("GET"));
-            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
-            if (Math.Abs(revenue) < 0.05f)
+            if (Math.Abs(revenue) > 0.05f)
             {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                {
-                    { "_idvc", "0" },
-                    { "_id", _sut.GetVisitorId() },
-                    { "idgoal", idGoal.ToString() },
-                });
+                expectedParameter.Add("revenue", revenue.ToString("0.##", CultureInfo.InvariantCulture));
             }
-            else
-            {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                {
-                    { "_idvc", "0" },
-                    { "_id", _sut.GetVisitorId() },
-                    { "idgoal", idGoal.ToString() },
-                    { "revenue", revenue.ToString("0.##",CultureInfo.InvariantCulture) },
-                });
-            }
+            Assert.PiwikRequestParameterMatch(actualRequest, expectedParameter);
         }
 
         [Test]
@@ -327,19 +243,15 @@ namespace Piwik.Tracker.Tests
             var actual = _sut.DoTrackAction(actionUrl, actionType);
             //Assert
             var actualRequest = retrieveRequest();
-            Assert.NotNull(actualRequest);
             Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(actualRequest.Method, Is.EqualTo("GET"));
-            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
 
+            Assert.PiwikRequestParameterMatch(actualRequest, new NameValueCollection
             {
-                Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
-                {
                     {"_idvc", "0"},
                     {"_id", _sut.GetVisitorId()},
                     {actionType.ToString(), actionUrl},
-                });
-            }
+             });
         }
 
         [Test]
@@ -353,12 +265,10 @@ namespace Piwik.Tracker.Tests
             var actual = _sut.DoTrackEcommerceCartUpdate(grandTotal);
             //Assert
             var actualRequest = retrieveRequest();
-            Assert.NotNull(actualRequest);
             Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(actualRequest.Method, Is.EqualTo("GET"));
-            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
 
-            Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+            Assert.PiwikRequestParameterMatch(actualRequest, new NameValueCollection
                 {
                     { "_idvc", "0" },
                     { "_id", _sut.GetVisitorId() },
@@ -394,10 +304,8 @@ namespace Piwik.Tracker.Tests
             Assert.That(_sut.GetStoredTrackingActions().Length, Is.EqualTo(0));
             //Assert
             var actualRequest = retrieveRequest();
-            Assert.NotNull(actualRequest);
             Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(actualRequest.Method, Is.EqualTo("POST"));
-            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
             if (string.IsNullOrEmpty(token))
             {
                 var body = JsonConvert.DeserializeObject<Dictionary<string, string[]>>(actualRequest.RequestBody.ToString()) as Dictionary<string, string[]>;
@@ -424,12 +332,10 @@ namespace Piwik.Tracker.Tests
             var actual = _sut.DoTrackEcommerceOrder(orderId, grandTotal, subTotal, tax, shipping, discount);
             //Assert
             var actualRequest = retrieveRequest();
-            Assert.NotNull(actualRequest);
             Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(actualRequest.Method, Is.EqualTo("GET"));
-            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
 
-            Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+            Assert.PiwikRequestParameterMatch(actualRequest, new NameValueCollection
                 {
                     { "_idvc", "0" },
                     { "_id", _sut.GetVisitorId() },
@@ -452,12 +358,10 @@ namespace Piwik.Tracker.Tests
             var actual = _sut.DoPing();
             //Assert
             var actualRequest = retrieveRequest();
-            Assert.NotNull(actualRequest);
             Assert.That(actual.HttpStatusCode, Is.EqualTo(HttpStatusCode.OK));
             Assert.That(actualRequest.Method, Is.EqualTo("GET"));
-            Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
 
-            Assert.PiwikRequestParameterMatch(actualRequest.RequestUri.ParseQueryString(), new NameValueCollection
+            Assert.PiwikRequestParameterMatch(actualRequest, new NameValueCollection
                 {
                     { "_idvc", "0" },
                     { "_id", _sut.GetVisitorId() },
@@ -487,9 +391,11 @@ namespace Piwik.Tracker.Tests
 
         internal class Assert : NUnit.Framework.Assert
         {
-            public static void PiwikRequestParameterMatch(NameValueCollection actualRequestParameter, NameValueCollection additionalExpectedParamters)
+            public static void PiwikRequestParameterMatch(ActualRequest actualRequest, NameValueCollection additionalExpectedParameter)
             {
-                var expectedRequestParameter = new NameValueCollection(DefaultRequestParameter) { additionalExpectedParamters };
+                Assert.That(actualRequest.RequestUri.GetAuthorityAndPath(), Is.EqualTo(PiwikBaseUrl));
+                var actualRequestParameter = actualRequest.RequestUri.ParseQueryString();
+                var expectedRequestParameter = new NameValueCollection(DefaultRequestParameter) { additionalExpectedParameter };
                 Assert.That(actualRequestParameter.AllKeys, Is.SupersetOf(DefaultRequestParameterKeysToRemoveFromComparison),
                     $"Request parameters must at least contain default Keys {string.Join(",", DefaultRequestParameterKeysToRemoveFromComparison)}.");
 
@@ -501,7 +407,7 @@ namespace Piwik.Tracker.Tests
 
                 Assert.That(actualRequestParameter.AllKeys, Is.EquivalentTo(expectedRequestParameter.AllKeys),
                     () => GetEnhancedMessage("Request parameter keys must be equivalent!", actualRequestParameter, expectedRequestParameter));
-                Assert.That(actualRequestParameter.AllKeys.Select(k => actualRequestParameter[k]), Is.EquivalentTo(expectedRequestParameter.AllKeys.Select(k => expectedRequestParameter[k])),
+                Assert.That(actualRequestParameter.AllKeys.Select(k => expectedRequestParameter[k]), Is.EquivalentTo(expectedRequestParameter.AllKeys.Select(k => expectedRequestParameter[k])),
                     () => GetEnhancedMessage("Request parameter values must be equivalent!", actualRequestParameter, expectedRequestParameter));
             }
 

--- a/Piwik.Tracker.Tests/UnitTestExtensions.cs
+++ b/Piwik.Tracker.Tests/UnitTestExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace Piwik.Tracker.Tests
+{
+    internal static class UnitTestExtensions
+    {
+        public static string GetAuthorityAndPath(this Uri uri)
+        {
+            return uri?.GetLeftPart(UriPartial.Path) ?? string.Empty;
+        }
+
+        public static IEnumerable<KeyValuePair<string, string>> ToKeyValuePairs(this NameValueCollection nameValueCollection)
+        {
+            return nameValueCollection.AllKeys.Select(k => new KeyValuePair<string, string>(k, nameValueCollection[(string)k]));
+        }
+    }
+}

--- a/Piwik.Tracker.Tests/app.config
+++ b/Piwik.Tracker.Tests/app.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Hosting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Piwik.Tracker.Tests/packages.config
+++ b/Piwik.Tracker.Tests/packages.config
@@ -1,4 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net461" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net461" />
+  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net461" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net461" />
+  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="NUnit" version="3.6.0" targetFramework="net45" />
+  <package id="Owin" version="1.0" targetFramework="net461" />
+  <package id="SimpleHttpMock" version="1.1.5" targetFramework="net461" />
 </packages>

--- a/Piwik.Tracker/PiwikTracker.cs
+++ b/Piwik.Tracker/PiwikTracker.cs
@@ -126,11 +126,11 @@ namespace Piwik.Tracker
         /// <summary>
         /// Ecommerce item page view tracking stores item's metadata in these Custom Variables slots.
         /// </summary>
-        private const int CvarIndexEcommerceItemPrice = 2;
+        internal const int CvarIndexEcommerceItemPrice = 2;
 
-        private const int CvarIndexEcommerceItemSku = 3;
-        private const int CvarIndexEcommerceItemName = 4;
-        private const int CvarIndexEcommerceItemCategory = 5;
+        internal const int CvarIndexEcommerceItemSku = 3;
+        internal const int CvarIndexEcommerceItemName = 4;
+        internal const int CvarIndexEcommerceItemCategory = 5;
 
         private const string DefaultCookiePath = "/";
 
@@ -397,6 +397,15 @@ namespace Piwik.Tracker
         }
 
         /// <summary>
+        /// Gets the stored tracking actions, that have been stored for bulkRequest <see cref="EnableBulkTracking"/>, <see cref="DoBulkTrack"/>.
+        /// </summary>
+        /// <returns></returns>
+        public string[] GetStoredTrackingActions()
+        {
+            return _storedTrackingActions.ToArray();
+        }
+
+        /// <summary>
         /// Clears any Custom Variable that may be have been set.
         ///
         /// This can be useful when you have enabled bulk requests,
@@ -575,7 +584,7 @@ namespace Piwik.Tracker
         /// </summary>
         /// <param name="bytes">The bytes.</param>
         /// <returns></returns>
-        protected string GetHexStringFromBytes(byte[] bytes)
+        protected static string GetHexStringFromBytes(byte[] bytes)
         {
             var sb = new StringBuilder();
             foreach (byte b in bytes)
@@ -884,7 +893,7 @@ namespace Piwik.Tracker
         /// <param name="shipping">The shipping.</param>
         /// <param name="discount">The discount.</param>
         /// <returns></returns>
-        protected string GetUrlTrackEcommerce(double grandTotal, double subTotal = 0, double tax = 0, double shipping = 0, double discount = 0)
+        protected internal string GetUrlTrackEcommerce(double grandTotal, double subTotal = 0, double tax = 0, double shipping = 0, double discount = 0)
         {
             string url = GetRequest(IdSite) + "&idgoal=0&revenue=" + FormatMonetaryValue(grandTotal);
 
@@ -1485,7 +1494,7 @@ namespace Piwik.Tracker
             return url;
         }
 
-        private string GetRequest(int idSite)
+        internal string GetRequest(int idSite)
         {
             SetFirstPartyCookies();
 

--- a/Piwik.Tracker/Properties/AssemblyInfo.cs
+++ b/Piwik.Tracker/Properties/AssemblyInfo.cs
@@ -1,7 +1,8 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("PiwikTracker")]
@@ -13,8 +14,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,11 +25,12 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.16.0")]
+[assembly: InternalsVisibleTo("Piwik.Tracker.Tests")]


### PR DESCRIPTION
* evaluated 3 HTTP server mocking libraries in order to substitute piwik server
  * [alexvictoor/mock4net:](https://github.com/alexvictoor/mock4net) not actively maintained since 2015, not released and no Nuget package available 
  * [richardszalay/mockhttp:](https://github.com/richardszalay/mockhttp) provides everything needed for a mocked server but depends on `HttpMessageHandler` and therefore a `System.Net.Http.HttpClient` object  for sending  requests (currently  `System.Net.HttpWebRequest` object is used by PiwikTracker to send requests).
  * [xiaoyvr/SimpleHttpMock](https://github.com/xiaoyvr/SimpleHttpMock): does not have the limitations mentioned before

* added Nuget SimpleHttpMock for mocking piwik server
* implemented several tests